### PR TITLE
Fixed typo in parameter name

### DIFF
--- a/dbt/include/mssql/macros/indexes.sql
+++ b/dbt/include/mssql/macros/indexes.sql
@@ -115,7 +115,7 @@ create clustered index
 
 {% macro create_nonclustered_index(columns, includes) %}
 
-{% if include_names is undefined %}
+{% if includes is undefined %}
 
 {{ log("Creating nonclustered index without include clause...") }}
 


### PR DESCRIPTION
The code for including columns in an index was looking for the wrong in-parameter. The parameter is <includes> but the if-statement looks for <include_names> instead of <includes>.  Original issue here: https://github.com/jacobm001/dbt-mssql/issues/21#issue-555841007